### PR TITLE
RowFormat formatter appends \tmessage in Tab separated format

### DIFF
--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -155,6 +155,7 @@ func (f *Formatter) rowMark(diff digest.Differences) error {
 	_, _ = fmt.Fprintf(f.stderr, "Rows:\n")
 
 	includes := f.ctx.GetIncludeColumnPositions()
+	separator := f.ctx.separator
 
 	additions := make([]string, 0, len(diff.Additions))
 	for _, addition := range diff.Additions {
@@ -172,15 +173,15 @@ func (f *Formatter) rowMark(diff digest.Differences) error {
 	}
 
 	for _, added := range additions {
-		_, _ = fmt.Fprintf(f.stdout, "%s,%s\n", added, "ADDED")
+		_, _ = fmt.Fprintf(f.stdout, "%s%s%s\n", added, string(separator), "ADDED")
 	}
 
 	for _, modified := range modifications {
-		_, _ = fmt.Fprintf(f.stdout, "%s,%s\n", modified, "MODIFIED")
+		_, _ = fmt.Fprintf(f.stdout, "%s%s%s\n", modified, string(separator), "MODIFIED")
 	}
 
 	for _, deleted := range deletions {
-		_, _ = fmt.Fprintf(f.stdout, "%s,%s\n", deleted, "DELETED")
+		_, _ = fmt.Fprintf(f.stdout, "%s%s%s\n", deleted, string(separator), "DELETED")
 	}
 
 	return nil

--- a/cmd/formatter_test.go
+++ b/cmd/formatter_test.go
@@ -95,6 +95,34 @@ Rows:
 	assert.Equal(t, expectedStderr, stderr.String())
 }
 
+func TestRowMarkFormatterForTabSeparator(t *testing.T) {
+	diff := digest.Differences{
+		Additions:     []digest.Addition{[]string{"additions"}},
+		Modifications: []digest.Modification{{Current: []string{"modification"}}},
+		Deletions:     []digest.Deletion{[]string{"deletions"}},
+	}
+	expectedStdout := `additions	ADDED
+modification	MODIFIED
+deletions	DELETED
+`
+	expectedStderr := `Additions 1
+Modifications 1
+Deletions 1
+Rows:
+`
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	formatter := NewFormatter(&stdout, &stderr, Context{format: "rowmark", separator: '\t'})
+
+	err := formatter.Format(diff)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStdout, stdout.String())
+	assert.Equal(t, expectedStderr, stderr.String())
+}
+
 func TestLineDiff(t *testing.T) {
 	t.Run("should show line diff with comma by default", func(t *testing.T) {
 		diff := digest.Differences{


### PR DESCRIPTION
Resolves #68 

It appends ADDED, MODIFIED, DELETED rowmarks using the file separator provided instead of the default.

Using the example in the bug ticket, I was able to generated the expected output.