### PR TITLE
Fix index out of range in formatter.go

### DIFF
--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -238,7 +238,7 @@ func (f *Formatter) wordLevelDiffs(diff digest.Differences, deletionFormat, addi
 	_, _ = fmt.Fprintln(f.stderr, blue("# Modifications (%d)", len(diff.Modifications)))
 	for _, modification := range diff.Modifications {
 		result := make([]string, 0, len(modification.Current))
-		for i := 0; i < len(includes) || i < len(modification.Current); i++ {
+		for i := 0; i < len(includes) && i < len(modification.Current); i++ {
 			if modification.Original[i] != modification.Current[i] {
 				removed := red(deletionFormat, modification.Original[i])
 				added := green(additionFormat, modification.Current[i])


### PR DESCRIPTION
Fixes:

panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/aswinkarthik/csvdiff/cmd.(*Formatter).wordLevelDiffs(0xc000081ac0, 0xc0014ec000, 0x4b7, 0x555, 0xc001628000, 0xfbc, 0x12aa, 0xc0005b0000, 0x409, 0x555, ...)
        /home/travis/gopath/src/github.com/aswinkarthik/csvdiff/cmd/formatter.go:242 +0x133f
github.com/aswinkarthik/csvdiff/cmd.(*Formatter).colorWords(...)
        /home/travis/gopath/src/github.com/aswinkarthik/csvdiff/cmd/formatter.go:221
github.com/aswinkarthik/csvdiff/cmd.(*Formatter).Format(0xc000081ac0, 0xc0014ec000, 0x4b7, 0x555, 0xc001628000, 0xfbc, 0x12aa, 0xc0005b0000, 0x409, 0x555, ...)
        /home/travis/gopath/src/github.com/aswinkarthik/csvdiff/cmd/formatter.go:53 +0x40b
github.com/aswinkarthik/csvdiff/cmd.runContext(0xc00010a000, 0x8766e0, 0xc000006018, 0x8766e0, 0xc000006020, 0x0, 0x0)
        /home/travis/gopath/src/github.com/aswinkarthik/csvdiff/cmd/root.go:108 +0x4cc
github.com/aswinkarthik/csvdiff/cmd.glob..func2(0xadb620, 0xc0000f2000, 0x2, 0x6, 0x0, 0x0)
        /home/travis/gopath/src/github.com/aswinkarthik/csvdiff/cmd/root.go:87 +0x28a
github.com/spf13/cobra.(*Command).execute(0xadb620, 0xc000092010, 0x6, 0x7, 0xadb620, 0xc000092010)
        /home/travis/gopath/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x467
github.com/spf13/cobra.(*Command).ExecuteC(0xadb620, 0xc000042d40, 0xc000089f20, 0x43e231)
        /home/travis/gopath/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x302
github.com/spf13/cobra.(*Command).Execute(...)
        /home/travis/gopath/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/aswinkarthik/csvdiff/cmd.Execute()
        /home/travis/gopath/src/github.com/aswinkarthik/csvdiff/cmd/root.go:115 +0x7d
main.main()
        /home/travis/gopath/src/github.com/aswinkarthik/csvdiff/main.go:29 +0x60